### PR TITLE
fix: getStarkName proper function

### DIFF
--- a/pages/devs/starknetjs.mdx
+++ b/pages/devs/starknetjs.mdx
@@ -54,7 +54,7 @@ const provider = new Provider({
   sequencer: { network: constants.NetworkName.SN_MAIN },
 });
 
-const address = await provider.getAddressFromStarkName(address ?? "");
+const name = await provider.getStarkName(address ?? "");
 ```
 
 ---


### PR DESCRIPTION
Fix:
User proper `getStarkName` function in **Example Usage**

#36 